### PR TITLE
Update focus mode styling and behavior

### DIFF
--- a/src/components/tiptap.tsx
+++ b/src/components/tiptap.tsx
@@ -11,7 +11,7 @@ export default function Tiptap({
     extensions: [
       StarterKit,
       Focus.configure({
-        mode: 'deepest',
+        mode: 'all',
       }),
     ],
     content: `<p>I am building a new project to help me write better, I mean a lot better.</p>

--- a/src/index.css
+++ b/src/index.css
@@ -128,6 +128,12 @@
   @apply h-full p-4 caret-blue-600 outline-0 dark:caret-blue-500;
 }
 
+/* Dim everything except focused */
 .focus-mode .tiptap *:not(.has-focus) {
-  @apply opacity-50 transition-opacity duration-200;
+  @apply text-muted-foreground/50 transition-colors duration-200;
+}
+
+/* Dim list markers too */
+.focus-mode .tiptap *:not(.has-focus)::marker {
+  @apply text-muted-foreground/50;
 }


### PR DESCRIPTION
- `opacity` will cascade so using `color` to dim instead
- Also, setting the `.has-focus` on parent nodes (for example lists)